### PR TITLE
(fix) add theme variable inside themewrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import childrenWithProps from './src/childrenWithProps'
 
 export default (CMP, theme, i18n) => {
   translate.setI18n(i18n)
-  return translate()(ThemeWrapper(ApolloWrapper(CMP)), theme)
+  return translate()(ThemeWrapper(ApolloWrapper(CMP), theme))
 }
  
 export class Provider extends Component {


### PR DESCRIPTION
it was probably a typo that prevented the theme object to be injected correctly into the `themewrapper` function